### PR TITLE
Added new config to ignore convert date in multilingual projects

### DIFF
--- a/config/filament-jalali.php
+++ b/config/filament-jalali.php
@@ -3,4 +3,5 @@
 return [
     'date_format' => 'Y/m/d',
     'datetime_format' => 'Y/m/d H:i:s',
+    'ignore_convert' => false,
 ];

--- a/src/FilamentJalaliServiceProvider.php
+++ b/src/FilamentJalaliServiceProvider.php
@@ -54,9 +54,14 @@ class FilamentJalaliServiceProvider extends PackageServiceProvider
                     return null;
                 }
 
-                return Jalali::fromCarbon(Carbon::parse($state)
-                    ->setTimezone($timezone ?? $column->getTimezone()))
-                    ->format($format);
+                //changed by Fatehi:                
+                if (!(config('filament-jalali.ignore_convert'))){
+                    $state=Jalali::fromCarbon(Carbon::parse($state)
+                        ->setTimezone($timezone ?? $column->getTimezone()))
+                        ->format($format);
+                }
+
+                return $state;
             });
 
             return $this;
@@ -79,9 +84,17 @@ class FilamentJalaliServiceProvider extends PackageServiceProvider
                     return null;
                 }
 
-                return Jalali::fromCarbon(Carbon::parse($state)
-                    ->setTimezone($timezone))
-                    ->format($format);
+
+                //changed by Fatehi:                
+                if (!(config('filament-jalali.ignore_convert'))){
+                    $state=Jalali::fromCarbon(Carbon::parse($state)
+                        ->setTimezone($timezone))
+                        ->format($format);
+                }
+                return $state;
+                // return Jalali::fromCarbon(Carbon::parse($state)
+                //     ->setTimezone($timezone))
+                //     ->format($format);
             });
 
             return $this;
@@ -96,10 +109,13 @@ class FilamentJalaliServiceProvider extends PackageServiceProvider
         });
 
         DateTimePicker::macro('jalali', function () {
-            $this
-                ->native(false)
-                ->firstDayOfWeek(6)
-                ->view('filament-jalali::jalali-date-time-picker');
+            //changed by Fatehi:
+            if (!(config('filament-jalali.ignore_convert'))){            
+                $this
+                    ->native(false)
+                    ->firstDayOfWeek(6)
+                    ->view('filament-jalali::jalali-date-time-picker');
+            }
 
             return $this;
         });


### PR DESCRIPTION
In multilingual projects, changing a config, will ignores converting dates and also opens native Filament calendar that is in Georgian format.
This added config is: 'ignore_convert'
