### PR TITLE
 Add Laravel 12 to test workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.1]
-        laravel: [11.*, 10.*]
+        laravel: [12.*, 11.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -22,6 +22,9 @@ jobs:
             carbon: ^2.63
           - laravel: 11.*
             testbench: 9.*
+            carbon: ^3.0
+          - laravel: 12.*
+            testbench: 10.*
             carbon: ^3.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}


### PR DESCRIPTION
This pull request adds Laravel 12 to the test workflow. Currently, the package is not being tested against Laravel 12, which was also mentioned by the previous [RP](https://github.com/mokhosh/filament-jalali/pull/22#issuecomment-2705327290).

By adding Laravel 12 to `.github/workflows/run-tests.yml`, I am confident that this issue is resolved. Let me know if any modifications are needed.

Thanks!