### PR TITLE
This PR fixing the GitHub Actions workflow for running tests.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,19 +13,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.1]
-        laravel: [12.*, 11.*, 10.*]
+        php: [8.2]
+        laravel: [12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.63
           - laravel: 11.*
             testbench: 9.*
             carbon: ^3.0
           - laravel: 12.*
             testbench: 10.*
-            carbon: ^3.0
+            carbon: ^3.8.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 


### PR DESCRIPTION
1. **Removed Support for Laravel 10**  
   - Tests now only run on **Laravel 11 and 12**.  
   - This prevents compatibility issues with `pestphp/pest`.  

2. **Dropped PHP 8.1 Due to Laravel 11 & 12 Incompatibility**  
   - Tests now only run on **PHP 8.2**.  
   - Laravel 11 & 12 does not support PHP 8.1, so it has been removed from the matrix.  

3. **Change Carbon Version for Laravel 12 Test**  
   - **Laravel 12** now uses `nesbot/carbon:^3.8.4`.  
