### PR TITLE
افزودن پارامتر قابل تنظیم toLatin به ماکروهای تاریخ جلالی

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ Components\TextEntry::make('updated_at')
     ->jalaliDateTime(),
 ```
 
+### Force Latin or Farsi Numbers
+By default, numbers follow the app locale. You can override this using the `latinNumbers` argument:
+
+```php
+use Filament\Tables;
+use Filament\Infolists\Components;
+
+Tables\Columns\TextColumn::make('created_at')
+    ->jalaliDate('Y-m-d', latinNumbers: true), // 1369-06-21
+
+Tables\Columns\TextColumn::make('updated_at')
+    ->jalaliDateTime('Y-m-d H:i:s', latinNumbers: false), // ۱۳۶۹-۰۶-۲۱ ۱۳:۱۴:۱۵
+
+Components\TextEntry::make('created_at')
+    ->jalaliDate('Y-m-d', latinNumbers: true),
+
+Components\TextEntry::make('updated_at')
+    ->jalaliDateTime('Y-m-d H:i:s', latinNumbers: false),
+```
+
 To add Jalali date and date-time pickers to your forms, just add `jalali`to your `DatePicker` and `DateTimePicker`.
 
 ```php

--- a/src/FilamentJalaliServiceProvider.php
+++ b/src/FilamentJalaliServiceProvider.php
@@ -31,10 +31,10 @@ class FilamentJalaliServiceProvider extends PackageServiceProvider
             AlpineComponent::make('filament-jalali', __DIR__.'/../resources/js/dist/components/filament-jalali.js'),
         ], 'mokhosh/filament-jalali');
 
-        TextColumn::macro('jalaliDate', function (string|Closure|null $format = null, ?string $timezone = null) {
+        TextColumn::macro('jalaliDate', function (string|Closure|null $format = null, ?string $timezone = null, ?bool $latinNumbers = null) {
             $format ??= fn (TextColumn $column): string => $column->getTable()->getDefaultDateDisplayFormat();
 
-            $this->formatStateUsing(static function (TextColumn $column, $state) use ($format, $timezone): ?string {
+            $this->formatStateUsing(static function (TextColumn $column, $state) use ($format, $timezone, $latinNumbers): ?string {
                 if (blank($state)) {
                     return null;
                 }
@@ -46,25 +46,25 @@ class FilamentJalaliServiceProvider extends PackageServiceProvider
                     Jalalian::fromCarbon(
                         Carbon::parse($state)->setTimezone($timezone ?? $column->getTimezone())
                     )->format($format),
-                    ! App::isLocale('fa')
+                    $latinNumbers ?? ! App::isLocale('fa')
                 );
             });
 
             return $this;
         });
 
-        TextColumn::macro('jalaliDateTime', function (string|Closure|null $format = null, ?string $timezone = null) {
+        TextColumn::macro('jalaliDateTime', function (string|Closure|null $format = null, ?string $timezone = null, ?bool $latinNumbers = null) {
             $format ??= fn (TextColumn $column): string => $column->getTable()->getDefaultDateTimeDisplayFormat();
 
-            $this->jalaliDate($format, $timezone);
+            $this->jalaliDate($format, $timezone, $latinNumbers);
 
             return $this;
         });
 
-        TextEntry::macro('jalaliDate', function (string|Closure|null $format = null, ?string $timezone = null) {
+        TextEntry::macro('jalaliDate', function (string|Closure|null $format = null, ?string $timezone = null, ?bool $latinNumbers = null) {
             $format ??= fn (TextEntry $component): string => $component->getContainer()->getDefaultDateDisplayFormat();
 
-            $this->formatStateUsing(static function (TextEntry $component, $state) use ($format, $timezone): ?string {
+            $this->formatStateUsing(static function (TextEntry $component, $state) use ($format, $timezone, $latinNumbers): ?string {
                 if (blank($state)) {
                     return null;
                 }
@@ -76,17 +76,17 @@ class FilamentJalaliServiceProvider extends PackageServiceProvider
                     Jalalian::fromCarbon(
                         Carbon::parse($state)->setTimezone($component->evaluate($timezone) ?? $component->getTimezone())
                     )->format($format),
-                    ! App::isLocale('fa')
+                    $latinNumbers ?? ! App::isLocale('fa')
                 );
             });
 
             return $this;
         });
 
-        TextEntry::macro('jalaliDateTime', function (string|Closure|null $format = null, ?string $timezone = null) {
+        TextEntry::macro('jalaliDateTime', function (string|Closure|null $format = null, ?string $timezone = null, ?bool $latinNumbers = null) {
             $format ??= fn (TextEntry $component): string => $component->getContainer()->getDefaultDateTimeDisplayFormat();
 
-            $this->jalaliDate($format, $timezone);
+            $this->jalaliDate($format, $timezone, $latinNumbers);
 
             return $this;
         });

--- a/tests/Tests/FilamentJalaliTest.php
+++ b/tests/Tests/FilamentJalaliTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Schemas\Schema as Infolist;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\App;
 
 it('formats state to jalali date', function () {
     Table::configureUsing(function (Table $table) {
@@ -40,22 +43,27 @@ it('formats state based on default date display format', function () {
 });
 
 it('uses farsi numbers if app locale is fa', function () {
+    $locale = App::getLocale();
     App::setLocale('fa');
 
-    Table::configureUsing(function (Table $table) {
-        $table->defaultDateDisplayFormat('F d, Y');
-    });
+    try {
+        Table::configureUsing(function (Table $table) {
+            $table->defaultDateDisplayFormat('F d, Y');
+        });
 
-    $page = new ListRecords;
-    $table = Table::make($page);
+        $page = new ListRecords;
+        $table = Table::make($page);
 
-    $column = TextColumn::make('created_at');
-    $column->table($table);
+        $column = TextColumn::make('created_at');
+        $column->table($table);
 
-    expect($column)
-        ->jalaliDate()
-        ->formatState(Carbon::parse('1989-10-07'))
-        ->toBe('مهر ۱۵, ۱۳۶۸');
+        expect($column)
+            ->jalaliDate()
+            ->formatState(Carbon::parse('1989-10-07'))
+            ->toBe('مهر ۱۵, ۱۳۶۸');
+    } finally {
+        App::setLocale($locale);
+    }
 });
 
 it('evaluates closures for format', function () {
@@ -80,4 +88,98 @@ it('evaluates closures for format', function () {
         ->record($newRecord)
         ->formatState($newRecord['created_at'])
         ->toBe(now()->format('H:i:s'));
+});
+
+it('uses latin numbers when explicitly enabled for text columns', function () {
+    $locale = App::getLocale();
+    App::setLocale('fa');
+
+    try {
+        $page = new ListRecords;
+        $table = Table::make($page);
+
+        $column = TextColumn::make('created_at');
+        $column->table($table);
+
+        expect($column)
+            ->jalaliDate('Y-m-d', latinNumbers: true)
+            ->formatState(Carbon::parse('1990-09-12'))
+            ->toBe('1369-06-21');
+    } finally {
+        App::setLocale($locale);
+    }
+});
+
+it('uses farsi numbers when explicitly disabled for text columns', function () {
+    $locale = App::getLocale();
+    App::setLocale('en');
+
+    try {
+        $page = new ListRecords;
+        $table = Table::make($page);
+
+        $column = TextColumn::make('created_at');
+        $column->table($table);
+
+        expect($column)
+            ->jalaliDate('Y-m-d', latinNumbers: false)
+            ->formatState(Carbon::parse('1990-09-12'))
+            ->toBe('۱۳۶۹-۰۶-۲۱');
+    } finally {
+        App::setLocale($locale);
+    }
+});
+
+it('passes latin numbers option to jalali date time for text columns', function () {
+    $locale = App::getLocale();
+    App::setLocale('en');
+
+    try {
+        $page = new ListRecords;
+        $table = Table::make($page);
+
+        $column = TextColumn::make('created_at');
+        $column->table($table);
+
+        expect($column)
+            ->jalaliDateTime('Y-m-d H:i:s', latinNumbers: false)
+            ->formatState(Carbon::parse('1990-09-12 13:14:15'))
+            ->toBe('۱۳۶۹-۰۶-۲۱ ۱۳:۱۴:۱۵');
+    } finally {
+        App::setLocale($locale);
+    }
+});
+
+it('uses latin numbers when explicitly enabled for text entries', function () {
+    $locale = App::getLocale();
+    App::setLocale('fa');
+
+    try {
+        $infolist = Infolist::make();
+
+        expect(TextEntry::make('created_at'))
+            ->container($infolist)
+            ->jalaliDate('Y-m-d', latinNumbers: true)
+            ->formatState(Carbon::parse('1990-09-12'))
+            ->toBe('1369-06-21');
+    } finally {
+        App::setLocale($locale);
+    }
+});
+
+it('passes latin numbers option to jalali date time for text entries', function () {
+    $locale = App::getLocale();
+    App::setLocale('en');
+
+    try {
+        $infolist = Infolist::make();
+
+        expect(TextEntry::make('created_at'))
+            ->container($infolist)
+            ->jalaliDateTime('Y-m-d H:i:s', latinNumbers: false)
+            ->formatState(Carbon::parse('1990-09-12 13:14:15'))
+            ->toBe('۱۳۶۹-۰۶-۲۱ ۱۳:۱۴:۱۵');
+    } finally {
+        App::setLocale($locale);
+    }
 });


### PR DESCRIPTION
بهبود ماکروهای jalaliDate و jalaliDateTime برای پذیرش پارامتر اختیاری toLatin، که به کاربران امکان کنترل رفتار تبدیل اعداد (اعداد لاتین در مقابل فارسی) را می‌دهد به جای اتکا صرف بر تشخیص زبان.

- افزودن پارامتر اختیاری toLatin به تمام ماکروهای تاریخ جلالی
- کاربران اکنون می‌توانند اعداد لاتین را با toLatin: true یا اعداد فارسی را با toLatin: false اجباری کنند