### PR TITLE
Add PHPStan extension and macro stubs for filament-jalali methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ You can install the package via composer:
 composer require mokhosh/filament-jalali
 ```
 
+## PHPStan / Larastan
+
+This package ships a PHPStan extension file (`extension.neon`) and macro stubs for:
+- `Filament\Tables\Columns\TextColumn`
+- `Filament\Infolists\Components\TextEntry`
+- `Filament\Forms\Components\DateTimePicker`
+
+If you use `phpstan/extension-installer`, it is discovered automatically.
+
+If you do not use extension-installer, add this include to your `phpstan.neon`:
+
+```neon
+includes:
+    - vendor/mokhosh/filament-jalali/extension.neon
+```
+
 ## Usage
 
 To add Jalali date and date-time columns to your tables, just add `jalaliDate` and `jalaliDateTime` to the filament `TextColumn`s instead of `date` or `dateTime`.

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,11 @@
         }
     },
     "extra": {
+        "phpstan": {
+            "includes": [
+                "extension.neon"
+            ]
+        },
         "laravel": {
             "providers": [
                 "Mokhosh\\FilamentJalali\\FilamentJalaliServiceProvider"

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,3 @@
+parameters:
+    stubFiles:
+        - stubs/filament-jalali.stub

--- a/stubs/filament-jalali.stub
+++ b/stubs/filament-jalali.stub
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filament\Forms\Components;
+
+/**
+ * @method $this jalali(bool $weekdaysShort = true)
+ */
+class DateTimePicker {}
+
+namespace Filament\Infolists\Components;
+
+/**
+ * @method $this jalaliDate(string|\Closure|null $format = null, ?string $timezone = null)
+ * @method $this jalaliDateTime(string|\Closure|null $format = null, ?string $timezone = null)
+ */
+class TextEntry {}
+
+namespace Filament\Tables\Columns;
+
+/**
+ * @method $this jalaliDate(string|\Closure|null $format = null, ?string $timezone = null)
+ * @method $this jalaliDateTime(string|\Closure|null $format = null, ?string $timezone = null)
+ */
+class TextColumn {}


### PR DESCRIPTION
Larastan/PHPStan cannot detect filament-jalali macro methods (jalaliDate, jalaliDateTime, jalali)